### PR TITLE
fix: Make Ruby 3.0 compatible

### DIFF
--- a/lib/crono/performer_proxy.rb
+++ b/lib/crono/performer_proxy.rb
@@ -8,7 +8,7 @@ module Crono
     end
 
     def every(period, *args)
-      @job = Job.new(@performer, Period.new(period, *args), @job_args, @options)
+      @job = Job.new(@performer, Period.new(period, **args), @job_args, @options)
       @scheduler.add_job(@job)
       self
     end


### PR DESCRIPTION
To avoid the following error:

```
Jul  7 18:18:10 binity-production-1 crono[967]: wrong number of arguments (given 2, expected 1)
Jul  7 18:18:10 binity-production-1 crono[967]: /usr/local/rvm/gems/ruby-3.0.4/gems/crono-1.1.2/lib/crono/period.rb:7:in `initialize'
Jul  7 18:18:10 binity-production-1 crono[967]: /usr/local/rvm/gems/ruby-3.0.4/gems/crono-1.1.2/lib/crono/performer_proxy.rb:11:in `new'
??? 
```

This fix is based on crono version 1.1.2 (plus a few commits) to use the same one we are using atm in Binity.